### PR TITLE
Add download code and test code for download eval data.

### DIFF
--- a/src/download_tool/data_utils.py
+++ b/src/download_tool/data_utils.py
@@ -97,10 +97,11 @@ def parse_qe_jsonl(input_file, output_path):
             download_list.append((url, os.path.join(output_path, f"{pid}.jpg")))
 
             # Extract information for all candidates.
-            for candidate in data_dict["candidates"]:
-                pid = candidate["candidate_pid"]
-                url = f"https://m.media-amazon.com/images/I/{pid}.jpg"
-                download_list.append((url, os.path.join(output_path, f"{pid}.jpg")))
+            if "candidates" in data_dict:
+                for candidate in data_dict["candidates"]:
+                    pid = candidate["candidate_pid"]
+                    url = f"https://m.media-amazon.com/images/I/{pid}.jpg"
+                    download_list.append((url, os.path.join(output_path, f"{pid}.jpg")))
 
     return download_list
 

--- a/test/test_data_download.py
+++ b/test/test_data_download.py
@@ -137,6 +137,13 @@ def test_parse_qe_jsonl():
                     },
                 ],
             },
+            {
+                "source_asin": "B078KHB3G7",
+                "source_pid": "81010ZkFvBL",
+                "utterance1": "a",
+                "utterance2": "b",
+                "utterance3": "c"
+            },
         ]
 
         file_handle = MagicMock()
@@ -169,6 +176,10 @@ def test_parse_qe_jsonl():
             (
                 "https://m.media-amazon.com/images/I/A1eVxp1fToL.jpg",
                 "test/A1eVxp1fToL.jpg",
+            ),
+            (
+                "https://m.media-amazon.com/images/I/81010ZkFvBL.jpg",
+                "test/81010ZkFvBL.jpg",
             ),
         ]
 
@@ -227,3 +238,11 @@ def test_data_download():
         data_download.data_download("test", "test", "annotation_csv", 3)
         data_download.data_download("test", "test", "gallery_csv", -1)
         data_download.data_download("test", "test", "qe_jsonl", -1)
+
+
+if __name__ == '__main__':
+    test_data_download()
+    test_parse_qe_jsonl()
+    test_parse_gallery_csv()
+    test_parse_csv_annotation()
+    test_download_url()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We add download code for eval data. In the eval query file, there is no "candidate" provided. I fixed the code to support the download of eval data. 

Test code is also added. 
